### PR TITLE
lefthookとCIを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Format check
+        run: pnpm run format:check
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm run test run --passWithNoTests
+
+      - name: Build
+        run: pnpm run build

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+pre-push:
+  parallel: true
+  jobs:
+    - name: lint
+      run: pnpm run lint
+
+    - name: format
+      run: pnpm run format:check
+
+    - name: typecheck
+      run: pnpm exec tsc --noEmit
+
+    - name: test
+      run: pnpm run test run --passWithNoTests

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
-    "test": "vitest"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "check": "pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test run --passWithNoTests",
+    "prepare": "lefthook install"
   },
   "dependencies": {
     "framer-motion": "^12.23.26",
@@ -41,6 +44,7 @@
     "gh-pages": "^6.3.0",
     "globals": "^16.5.0",
     "jsdom": "^27.3.0",
+    "lefthook": "^2.0.12",
     "postcss-nesting": "^13.0.2",
     "prettier": "^3.7.4",
     "tsx": "^4.21.0",
@@ -49,5 +53,8 @@
     "vite": "^7.3.0",
     "vitest": "^4.0.16"
   },
-  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
+  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39",
+  "pnpm": {
+    "onlyBuiltDependencies": ["lefthook"]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       jsdom:
         specifier: ^27.3.0
         version: 27.3.0(canvas@3.1.1)(postcss@8.5.6)
+      lefthook:
+        specifier: ^2.0.12
+        version: 2.0.12
       postcss-nesting:
         specifier: ^13.0.2
         version: 13.0.2(postcss@8.5.6)
@@ -1388,6 +1391,60 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lefthook-darwin-arm64@2.0.12:
+    resolution: {integrity: sha512-tuBz1sNLien+nKKb8BDopKjS6EnbXU8rQzhMVBY+bnVfsTiYDfbBr4wo/IzA5TcwoTL/b5somCJhljEw6DvSyg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.0.12:
+    resolution: {integrity: sha512-FnuUMPPRMJyTEPXg6PotSrFJ8qf8FDLhhD1zLh74D+9Cye5j9n3lcrCQEjXubPT8du/GZLxMBjjffRbcZ8eYDA==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.0.12:
+    resolution: {integrity: sha512-DXElB0qR5e6a8cXkFNYakhwCieypbfh6Y4QG39pzMnLsG03g/nhe093o6owfiUZ4mUFyDM6+0xmy0steOooF2g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.0.12:
+    resolution: {integrity: sha512-iJN1ZxFeaDi4Fi3b9jcW9wgyNl19LOv2NaVOaAi/tG6mlIn196cmSdXkOA3+943ZbqbdfV9I+bBcIKwneXDA3Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.0.12:
+    resolution: {integrity: sha512-byvmO4Iri6P0COwM8c3lGgeCV3Q0hh1XJpRfrcZDr4Wslq9O63t6J3T6i87oOtY+UjC9pXLl6xGk6hlUcHZ3BQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.0.12:
+    resolution: {integrity: sha512-KBaiinmf336rA+/dmYs7H7TTeAOByB0CyLA7k8IecTCuaiuKr6ez7ktSjht19poa5G+V0mts4GgEGcx6HViR0w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.0.12:
+    resolution: {integrity: sha512-1QBMXX1UW5rtgC4TB52OKWB7Rz/kCBRB+bKKLT/gDD79aPzLgJANTitQQzgFNIWoa7aM9UvzvIAJzOo6FcFIbg==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.0.12:
+    resolution: {integrity: sha512-zPcvUzs65GexRA37UHmaZqWuEGSU/zpBaPIY98MybXzzcJfCIf+O0oUQe2riMllwYGvNW0B1y3NOYRziDNe/vA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.0.12:
+    resolution: {integrity: sha512-kgwxguS2GssoHM4SMTp+ArD/Gjg9q5MinD6iI5vSFpuJygD13ZWiXQQfESMHq9y/v1XkD0BdHTJej49dx8P+Vw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.0.12:
+    resolution: {integrity: sha512-Tf/VtSOtF3rBTc9dzRWROa+HuhqaiIV+Xp+1gzlx5+uCueLM0m87Rz6yd4IN5mL7TrDaNkiRXI3FvjCp0dUE4Q==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.0.12:
+    resolution: {integrity: sha512-I2FdA9cdnq1icwlNz4RADs7exuqe47q1N9+p2LmcP/WfchWh16mvTB82OAD7w7zK9GxblS9GpF7pASaOSl4c7A==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3293,6 +3350,49 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  lefthook-darwin-arm64@2.0.12:
+    optional: true
+
+  lefthook-darwin-x64@2.0.12:
+    optional: true
+
+  lefthook-freebsd-arm64@2.0.12:
+    optional: true
+
+  lefthook-freebsd-x64@2.0.12:
+    optional: true
+
+  lefthook-linux-arm64@2.0.12:
+    optional: true
+
+  lefthook-linux-x64@2.0.12:
+    optional: true
+
+  lefthook-openbsd-arm64@2.0.12:
+    optional: true
+
+  lefthook-openbsd-x64@2.0.12:
+    optional: true
+
+  lefthook-windows-arm64@2.0.12:
+    optional: true
+
+  lefthook-windows-x64@2.0.12:
+    optional: true
+
+  lefthook@2.0.12:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.0.12
+      lefthook-darwin-x64: 2.0.12
+      lefthook-freebsd-arm64: 2.0.12
+      lefthook-freebsd-x64: 2.0.12
+      lefthook-linux-arm64: 2.0.12
+      lefthook-linux-x64: 2.0.12
+      lefthook-openbsd-arm64: 2.0.12
+      lefthook-openbsd-x64: 2.0.12
+      lefthook-windows-arm64: 2.0.12
+      lefthook-windows-x64: 2.0.12
 
   levn@0.4.1:
     dependencies:

--- a/src/components/PdfScrollViewer.tsx
+++ b/src/components/PdfScrollViewer.tsx
@@ -26,6 +26,22 @@ export default function PdfScrollViewer({ file }: PdfScrollViewerProps) {
     [],
   );
 
+  const scrollToPage = useCallback((pageNumber: number) => {
+    const element = document.getElementById(`page-${pageNumber}`);
+    if (element) {
+      window.scrollTo({
+        top: element.offsetTop - 20,
+        behavior: "smooth",
+      });
+
+      // スクロール後にフラグをリセット
+      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
+      scrollTimeoutRef.current = setTimeout(() => {
+        setIsScrolling(false);
+      }, 600);
+    }
+  }, []);
+
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === "j" || event.key === "ArrowDown") {
@@ -42,24 +58,8 @@ export default function PdfScrollViewer({ file }: PdfScrollViewerProps) {
         scrollToPage(prevPage);
       }
     },
-    [numPages, currentPage],
+    [numPages, currentPage, scrollToPage],
   );
-
-  const scrollToPage = (pageNumber: number) => {
-    const element = document.getElementById(`page-${pageNumber}`);
-    if (element) {
-      window.scrollTo({
-        top: element.offsetTop - 20,
-        behavior: "smooth",
-      });
-
-      // スクロール後にフラグをリセット
-      if (scrollTimeoutRef.current) clearTimeout(scrollTimeoutRef.current);
-      scrollTimeoutRef.current = setTimeout(() => {
-        setIsScrolling(false);
-      }, 600);
-    }
-  };
 
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown);

--- a/src/components/PresentationMode.tsx
+++ b/src/components/PresentationMode.tsx
@@ -132,10 +132,10 @@ export default function PresentationMode({
   }, []);
 
   // メモリ節約のため、現在のページと前後数ページのみをレンダリング
-  const PRELOAD_RANGE = isMobile ? 1 : 2; // モバイルでは前後1ページ、デスクトップでは前後2ページ
   const pagesToRender = useMemo(() => {
-    const start = Math.max(1, currentPage - PRELOAD_RANGE);
-    const end = Math.min(numPages, currentPage + PRELOAD_RANGE);
+    const preloadRange = isMobile ? 1 : 2; // モバイルでは前後1ページ、デスクトップでは前後2ページ
+    const start = Math.max(1, currentPage - preloadRange);
+    const end = Math.min(numPages, currentPage + preloadRange);
     return Array.from({ length: end - start + 1 }, (_, i) => start + i);
   }, [currentPage, numPages, isMobile]);
 


### PR DESCRIPTION

依頼: lint/test/formatを回せるコマンドを作ってCIとpre-pushで回したい

実行内容:
- lefthookをインストールしてpre-pushフックを設定
  - lint, format:check, typecheck, testを並列実行
- package.jsonにスクリプト追加
  - typecheck: 型チェック
  - check: lint + format:check + typecheck + testをまとめて実行
  - prepare: pnpm install時にlefthookを自動セットアップ
  - pnpm.onlyBuiltDependencies: lefthookのビルド許可
- GitHub Actions CIワークフロー(.github/workflows/ci.yml)を作成
  - master pushとPRで実行
  - actionsはhash pinningでセキュリティ強化
- lintエラーを修正
  - PdfScrollViewer: scrollToPage関数の宣言順序を修正
  - PresentationMode: useMemoの依存配列警告を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
